### PR TITLE
[#77] 커밋헬퍼 이슈번호를 브랜치에서 파싱

### DIFF
--- a/scripts/commit-helper.js
+++ b/scripts/commit-helper.js
@@ -68,6 +68,14 @@ async function createCommit() {
       console.log(chalk.yellow('⚠️  커밋할 staged 변경사항이 없습니다.'));
     }
 
+    const branchName = execSync('git rev-parse --abbrev-ref HEAD', {
+      encoding: 'utf8',
+    }).trim();
+    const issueNumberMatch = branchName.match(/-(\d+)/);
+    const defaultIssueNumber = issueNumberMatch
+      ? issueNumberMatch[1]
+      : undefined;
+
     const questions = [
       {
         type: 'list',
@@ -92,8 +100,8 @@ async function createCommit() {
       {
         type: 'input',
         name: 'issueNumber',
-        message: '이슈 번호를 입력하세요 (숫자만):',
-        default: undefined,
+        message: `이슈 번호를 입력하세요 (숫자만) ${defaultIssueNumber ? `(기본값: ${defaultIssueNumber})` : ''}:`,
+        default: defaultIssueNumber,
         validate: function (value) {
           if (!value) {
             return '이슈 번호는 필수입니다.';


### PR DESCRIPTION
## 📝 변경 사항

yarn commit 시 이슈번호를 브랜치에서 가져오도록 수정했습니다.
기본값이고 변경 가능합니다.

## 🔗 연관된 이슈

Closes #77

## 📱 스크린샷 (UI 변경 시)

<!-- UI가 변경된 경우 Before/After 스크린샷을 첨부해주세요 -->

### Before

https://github.com/user-attachments/assets/e8f65b22-8f23-4cb4-adc7-8447ff26565d

## 📋 추가 정보

<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 작성해주세요 -->

### 리뷰 포인트

<!-- 특별히 리뷰받고 싶은 부분이 있다면 작성해주세요 -->

### 배포 시 주의사항

<!-- 배포할 때 주의해야 할 사항이 있다면 작성해주세요 -->

### Breaking Changes

<!-- 기존 코드나 API에 영향을 주는 변경사항이 있다면 작성해주세요 -->
