### PR TITLE
[#27] quiz열 추가

### DIFF
--- a/src/apps/quizzes/components/EditTableCell.tsx
+++ b/src/apps/quizzes/components/EditTableCell.tsx
@@ -1,0 +1,47 @@
+import { Input, InputNumber } from 'antd';
+import React from 'react';
+
+import type { Quiz } from '../mock/quizzes';
+
+const EditableCell: React.FC<{
+  editing: boolean;
+  dataIndex: keyof Quiz;
+  record: Quiz;
+  inputType: 'number' | 'text';
+  onSave: (key: string, dataIndex: keyof Quiz, value: unknown) => void;
+  children: React.ReactNode;
+  onDoubleClick: () => void;
+}> = ({
+  editing,
+  dataIndex,
+  record,
+  inputType,
+  onSave,
+  children,
+  onDoubleClick,
+}) => {
+  const inputNode =
+    inputType === 'number' ? (
+      <InputNumber
+        autoFocus
+        onBlur={(e) => onSave(record.id, dataIndex, e.target.value)}
+        onPressEnter={(e) =>
+          onSave(record.id, dataIndex, (e.target as HTMLInputElement).value)
+        }
+      />
+    ) : (
+      <Input
+        autoFocus
+        onBlur={(e) => onSave(record.id, dataIndex, e.target.value)}
+        onPressEnter={(e) =>
+          onSave(record.id, dataIndex, e.currentTarget.value)
+        }
+      />
+    );
+
+  return (
+    <td onDoubleClick={onDoubleClick}>{editing ? inputNode : children}</td>
+  );
+};
+
+export default EditableCell;

--- a/src/apps/quizzes/components/QuizzesTable.tsx
+++ b/src/apps/quizzes/components/QuizzesTable.tsx
@@ -1,27 +1,184 @@
-import { Select, Space, Table } from 'antd';
-import Column from 'antd/es/table/Column';
-import ColumnGroup from 'antd/es/table/ColumnGroup';
-import { useState } from 'react';
+import type { TableProps } from 'antd';
+import { Form, Input, InputNumber, Select, Table } from 'antd';
+import React, { useState } from 'react';
 
 import type { Quiz } from '../mock/quizzes';
 import { QUIZZES_MOCK_DATA } from '../mock/quizzes';
+
+interface EditableCellProps {
+  editing: boolean;
+  dataIndex: keyof Quiz;
+  record: Quiz;
+  inputType: 'number' | 'text' | 'select';
+  onSave: (key: string, dataIndex: keyof Quiz, value: unknown) => void;
+  children: React.ReactNode;
+  onDoubleClick: () => void;
+}
+
+const EditableCell: React.FC<EditableCellProps> = ({
+  editing,
+  dataIndex,
+  record,
+  inputType,
+  onSave,
+  children,
+  onDoubleClick,
+}) => {
+  let inputNode: React.ReactNode;
+
+  if (inputType === 'select') {
+    inputNode = (
+      <Select
+        autoFocus
+        defaultValue={record[dataIndex]}
+        style={{ width: '100%', minWidth: '120px' }}
+        onChange={(value) => onSave(record.id, dataIndex, value)}
+        options={[
+          { value: 'multipleChoice', label: '다중선택' },
+          { value: 'shortAnswer', label: '짧은 글' },
+          { value: 'selectPicture', label: '그림맞추기' },
+          { value: 'correctWords', label: '단어맞추기' },
+        ]}
+      />
+    );
+  } else if (inputType === 'number') {
+    inputNode = (
+      <InputNumber
+        autoFocus
+        onPressEnter={(e) =>
+          onSave(record.id, dataIndex, (e.target as HTMLInputElement).value)
+        }
+        onBlur={(e) => onSave(record.id, dataIndex, e.target.value)}
+      />
+    );
+  } else {
+    inputNode = (
+      <Input
+        autoFocus
+        onPressEnter={(e) =>
+          onSave(record.id, dataIndex, (e.target as HTMLInputElement).value)
+        }
+        onBlur={(e) => onSave(record.id, dataIndex, e.target.value)}
+      />
+    );
+  }
+
+  return (
+    <td onDoubleClick={onDoubleClick}>{editing ? inputNode : children}</td>
+  );
+};
+
 export default function QuizzesTable() {
   const [quizzes, setQuizzes] = useState<Quiz[]>(QUIZZES_MOCK_DATA);
+  const [editingCell, setEditingCell] = useState<{
+    key: string;
+    dataIndex: keyof Quiz;
+  } | null>(null);
+
+  const save = (key: string, dataIndex: keyof Quiz, value: unknown) => {
+    setQuizzes((prev) =>
+      prev.map((item) =>
+        item.id === key
+          ? { ...item, [dataIndex]: value, updatedAt: new Date().toISOString() }
+          : item
+      )
+    );
+    setEditingCell(null);
+  };
 
   const addQuizTableHandler = () => {
+    const newId = `new_${Date.now()}`;
     const newData: Quiz = {
-      id: '',
+      id: newId,
       question: '',
       answer: '',
       imageUrl: '',
       type: 'multipleChoice',
-      createdAt: '',
-      updatedAt: '',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
     };
-    setQuizzes((prev) => {
-      return [...prev, newData];
-    });
+    setQuizzes((prev) => [...prev, newData]);
   };
+
+  const columns: TableProps<Quiz>['columns'] = [
+    {
+      title: '타입',
+      dataIndex: 'type',
+      onCell: (record: Quiz) => ({
+        record,
+        inputType: 'select',
+        dataIndex: 'type',
+        editing: true,
+        onSave: save,
+        onDoubleClick: () =>
+          setEditingCell({ key: record.id, dataIndex: 'type' }),
+      }),
+      render: (type: Quiz['type']) => type,
+    },
+    {
+      title: '질문',
+      dataIndex: 'question',
+      onCell: (record: Quiz) => ({
+        record,
+        inputType: 'text',
+        dataIndex: 'question',
+        editing:
+          editingCell?.key === record.id &&
+          editingCell?.dataIndex === 'question',
+        onSave: save,
+        onDoubleClick: () =>
+          setEditingCell({ key: record.id, dataIndex: 'question' }),
+      }),
+    },
+    {
+      title: '정답',
+      dataIndex: 'answer',
+      onCell: (record: Quiz) => ({
+        record,
+        inputType: 'text',
+        dataIndex: 'answer',
+        editing:
+          editingCell?.key === record.id && editingCell?.dataIndex === 'answer',
+        onSave: save,
+        onDoubleClick: () =>
+          setEditingCell({ key: record.id, dataIndex: 'answer' }),
+      }),
+    },
+    {
+      title: '이미지',
+      dataIndex: 'imageUrl',
+      onCell: (record: Quiz) => ({
+        record,
+        inputType: 'text',
+        dataIndex: 'imageUrl',
+        editing:
+          editingCell?.key === record.id &&
+          editingCell?.dataIndex === 'imageUrl',
+        onSave: save,
+        onDoubleClick: () =>
+          setEditingCell({ key: record.id, dataIndex: 'imageUrl' }),
+      }),
+      render: (image: string) => {
+        if (!image) return null;
+        return (
+          <img
+            src={image}
+            alt="image"
+            width={50}
+            height={50}
+            style={{ objectFit: 'cover' }}
+          />
+        );
+      },
+    },
+    {
+      title: '시점',
+      children: [
+        { title: 'createdAt', dataIndex: 'createdAt', key: 'createdAt' },
+        { title: 'updatedAt', dataIndex: 'updatedAt', key: 'updatedAt' },
+      ],
+    },
+  ];
 
   return (
     <>
@@ -38,53 +195,20 @@ export default function QuizzesTable() {
       </header>
 
       <main className="p-6">
-        <section>
-          <Table<Quiz> dataSource={quizzes}>
-            <Column
-              title="타입"
-              dataIndex="type"
-              key="type"
-              render={(type) => (
-                <Space wrap>
-                  <Select
-                    defaultValue={type}
-                    style={{ width: 120 }}
-                    onChange={addQuizTableHandler}
-                    options={[
-                      { value: 'multipleChoice', label: '다중선택' },
-                      { value: 'shortAnswer', label: '짧은 글' },
-                      { value: 'selectPicture', label: '그림맞추기' },
-                      {
-                        value: 'correctWords',
-                        label: '단어맞추기',
-                        disabled: true,
-                      },
-                    ]}
-                  />
-                </Space>
-              )}
-            />
-            <Column title="질문" dataIndex="question" key="question" />
-            <Column title="정답" dataIndex="answer" key="answer" />
-            <Column
-              title="이미지"
-              dataIndex="imageUrl"
-              key="imageUrl"
-              render={(image) => {
-                if (!image) return null;
-                return (
-                  <>
-                    <img src={image} alt="image" width={50} height={50} />
-                  </>
-                );
-              }}
-            />
-            <ColumnGroup title="시점">
-              <Column title="createdAt" dataIndex="createdAt" key="createdAt" />
-              <Column title="updatedAt" dataIndex="updatedAt" key="updatedAt" />
-            </ColumnGroup>
-          </Table>
-        </section>
+        <Form component={false}>
+          <Table
+            components={{
+              body: {
+                cell: EditableCell,
+              },
+            }}
+            bordered
+            dataSource={quizzes}
+            columns={columns}
+            rowKey="id"
+            pagination={false}
+          />
+        </Form>
         <button
           onClick={addQuizTableHandler}
           className="bg-primary-600 px-2 py-1 mt-3 text-white rounded-lg hover:bg-primary-700 transition-colors cursor-pointer"

--- a/src/apps/quizzes/mock/quizzes.ts
+++ b/src/apps/quizzes/mock/quizzes.ts
@@ -1,3 +1,5 @@
+import type { TableProps } from 'antd';
+
 export type Quiz = {
   id: string;
   createdAt: string;
@@ -8,7 +10,7 @@ export type Quiz = {
   imageUrl: string | null;
 };
 
-export const columns = [
+export const columns: TableProps<Quiz>['columns'] = [
   {
     title: 'ID',
     dataIndex: 'id',
@@ -62,4 +64,13 @@ export const QUIZZES_MOCK_DATA: Quiz[] = [
     answer: 'Facebook (Meta)',
     imageUrl: 'https://images.unsplash.com/photo-1633356122544-f134324a6cee',
   },
+];
+
+export const IMAGE_GALLERY_MOCK = [
+  'https://images.unsplash.com/photo-1538485394074-75f3474c7590?q=80&w=200',
+  'https://images.unsplash.com/photo-1633356122544-f134324a6cee?q=80&w=200',
+  'https://images.unsplash.com/photo-1517694712202-14dd9538aa97?q=80&w=200',
+  'https://images.unsplash.com/photo-1550745165-9bc0b252726a?q=80&w=200',
+  'https://images.unsplash.com/photo-1587620962725-abab7fe55159?q=80&w=200',
+  'https://images.unsplash.com/photo-1498050108023-c5249f4df085?q=80&w=200',
 ];


### PR DESCRIPTION
## 📝 변경 사항

<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->
 
- `+` 버튼을 누르면 열이 추가됩니다. `antd`의 table과 제공해주는 `EditCell`로직을 활용해서 인라인으로 수정이 가능하도록 했습니다.

## 🔗 연관된 이슈

Closes #27

## 📱 스크린샷 (UI 변경 시)

<!-- UI가 변경된 경우 Before/After 스크린샷을 첨부해주세요 -->

### Before

<!-- 변경 전 스크린샷 -->

### After

https://github.com/user-attachments/assets/e7911d56-79ac-4c07-b7d8-a24706a545a0

<!-- 변경 후 스크린샷 -->

## 📋 추가 정보

<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 작성해주세요 -->

### 리뷰 포인트

<!-- 특별히 리뷰받고 싶은 부분이 있다면 작성해주세요 -->

- 사실 코드를 아직 다 이해하지 못했습니다. 추 후 각 셀의 상태 변환이나, 그래그 기능을 구현하기 위해서 조금 더 공부해 봐야 할 것 같습니다.

### 배포 시 주의사항

<!-- 배포할 때 주의해야 할 사항이 있다면 작성해주세요 -->

### Breaking Changes

<!-- 기존 코드나 API에 영향을 주는 변경사항이 있다면 작성해주세요 -->
