### PR TITLE
[#30] 퀴즈 이미지 단일 수정

### DIFF
--- a/src/apps/quizzes/components/CreateQuizzes/ImageDrawer.tsx
+++ b/src/apps/quizzes/components/CreateQuizzes/ImageDrawer.tsx
@@ -14,6 +14,8 @@ const ImageDrawer: React.FC<ImageGalleryProps> = ({ onSelect }) => {
         display: 'grid',
         gridTemplateColumns: 'repeat(2, 1fr)',
         gap: '16px',
+        maxHeight: 550,
+        overflow: 'auto',
       }}
     >
       {IMAGE_GALLERY_MOCK.map((imageUrl) => (

--- a/src/apps/quizzes/components/SingleQuiz/EditQuiz.tsx
+++ b/src/apps/quizzes/components/SingleQuiz/EditQuiz.tsx
@@ -5,7 +5,16 @@ import {
   useParams,
   useRouter,
 } from '@tanstack/react-router';
-import { Button, Card, Form, Image, Popconfirm, Select, Skeleton } from 'antd';
+import {
+  Button,
+  Card,
+  Form,
+  Image,
+  Popconfirm,
+  Select,
+  Skeleton,
+  Space,
+} from 'antd';
 import useApp from 'antd/es/app/useApp';
 import Input from 'antd/es/input/Input';
 import TextArea from 'antd/es/input/TextArea';
@@ -17,11 +26,13 @@ import type { UpdateQuizDto } from '@/lib/apis/_generated/quizzesGameIoBackend.s
 import { queryClient } from '@/lib/queryClient';
 import { quizQueries } from '@/shared/service/query/quiz';
 
+import ImageDrawer from '../CreateQuizzes/ImageDrawer';
+
 export default function EditQuiz() {
   const router = useRouter();
   const navigate = useNavigate();
   const [form] = Form.useForm<UpdateQuizDto>();
-  const { message } = useApp();
+  const { message, modal } = useApp();
   const [formIsDirty, setFormIsDirty] = useState(false);
 
   useBlocker({
@@ -81,6 +92,27 @@ export default function EditQuiz() {
     updateQuiz({ quizId, updateQuizDto: values });
   };
 
+  const showImagesModal = () => {
+    const modalInstance = modal.info({
+      title: '이미지 선택',
+      content: (
+        <ImageDrawer
+          onSelect={(imageUrl) => {
+            form.setFieldsValue({ imageUrl });
+            setFormIsDirty(true);
+            modalInstance.destroy();
+          }}
+        />
+      ),
+      icon: null,
+      width: 550,
+      footer: null,
+      closable: true,
+    });
+  };
+
+  const imageUrlValue = Form.useWatch('imageUrl', form);
+
   if (isLoading) {
     return (
       <div className="p-6">
@@ -109,12 +141,7 @@ export default function EditQuiz() {
         layout="vertical"
         onFinish={onFinish}
         onValuesChange={() => setFormIsDirty(true)}
-        initialValues={{
-          type: quiz.type,
-          question: quiz.question,
-          answer: quiz.answer,
-          imageUrl: quiz.imageUrl,
-        }}
+        initialValues={{ ...quiz }}
       >
         <Card
           title={<Title level={3}>퀴즈 수정</Title>}
@@ -141,16 +168,32 @@ export default function EditQuiz() {
           }
         >
           <div className="flex flex-col md:flex-row gap-8">
-            {quiz.imageUrl && (
-              <div className="flex-shrink-0 text-center">
-                <Image
-                  width={250}
-                  src={quiz.imageUrl}
-                  alt="퀴즈 이미지"
-                  className="rounded-lg shadow-sm"
-                />
-              </div>
-            )}
+            <Form.Item name="imageUrl" className="flex-shrink-0 text-center">
+              <Space direction="vertical">
+                {imageUrlValue ? (
+                  <Image
+                    width={250}
+                    src={imageUrlValue}
+                    alt="퀴즈 이미지"
+                    className="rounded-lg shadow-sm"
+                  />
+                ) : (
+                  <div
+                    className="w-[250px] h-[150px] bg-gray-200 rounded-lg flex items-center justify-center"
+                    style={{ border: '1px dashed #d9d9d9' }}
+                  >
+                    <span className="text-gray-500">이미지 없음</span>
+                  </div>
+                )}
+                <Button
+                  onClick={showImagesModal}
+                  type="primary"
+                  style={{ width: '100%' }}
+                >
+                  {imageUrlValue ? '이미지 변경' : '이미지 추가'}
+                </Button>
+              </Space>
+            </Form.Item>
             <div className="flex-grow">
               <Form.Item label="ID">
                 <Input value={quiz.id} disabled />

--- a/src/apps/quizzes/mock/quizzes.ts
+++ b/src/apps/quizzes/mock/quizzes.ts
@@ -41,4 +41,5 @@ export const QUIZZES_MOCK_DATA: Quiz[] = [
 export const IMAGE_GALLERY_MOCK = [
   'https://dev-zoop.s3.ap-northeast-2.amazonaws.com/images/766971239455110853.png',
   'https://dev-zoop.s3.ap-northeast-2.amazonaws.com/images/767309255440708414.webp',
+  'https://dev-zoop.s3.ap-northeast-2.amazonaws.com/quiz-images/769450269779152252.webp',
 ];


### PR DESCRIPTION
## 📝 변경 사항

<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->

## 🔗 연관된 이슈

Closes #30

## 📱 스크린샷 (UI 변경 시)

<!-- UI가 변경된 경우 Before/After 스크린샷을 첨부해주세요 -->

### Before

<!-- 변경 전 스크린샷 -->

### After
<img width="1582" height="1034" alt="스크린샷 2025-10-24 오후 3 43 07" src="https://github.com/user-attachments/assets/17debb97-6157-4c16-be77-9a25e66af643" />
- 이미지 불러오는 모달을 그대로 사용
<!-- 변경 후 스크린샷 -->

## 📋 추가 정보

<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 작성해주세요 -->

### 리뷰 포인트

- `ImageDrawer`컴포넌트가, `CreateQuizzes`에서도 사용되고, `SingleQuiz`에서도 사용되는데 두 개의 공통 부모에서 관리하는게 맞겠죠?

<!-- 특별히 리뷰받고 싶은 부분이 있다면 작성해주세요 -->

### 배포 시 주의사항

<!-- 배포할 때 주의해야 할 사항이 있다면 작성해주세요 -->

### Breaking Changes

<!-- 기존 코드나 API에 영향을 주는 변경사항이 있다면 작성해주세요 -->
